### PR TITLE
Fix for #21 (untested)

### DIFF
--- a/db/unit_set_to_unit_junctions_tables/zzz_cbfm_violent_hunger_skullcrusher_fix.tsv
+++ b/db/unit_set_to_unit_junctions_tables/zzz_cbfm_violent_hunger_skullcrusher_fix.tsv
@@ -1,0 +1,3 @@
+unit_set	unit_record	unit_caste	unit_category	unit_class	exclude
+#unit_set_to_unit_junctions_tables;1;db/unit_set_to_unit_junctions_tables/zzz_cbfm_violent_hunger_skullcrusher_fix					
+wh3_dlc20_chs_khorne_marked_units	wh3_main_kho_cav_skullcrushers_0				false


### PR DESCRIPTION
OG Khorne units (introduced before champs DLC) do not include the "mkho" signifier in their name, but they are nevertheless marked by Khorne. CA remembered this for warriors but apparently forgot for Skullcrushers.