### PR TITLE
Fix for issue #109

### DIFF
--- a/db/trait_level_effects_tables/zzz_cbfm_metal_wom_cost_fix.tsv
+++ b/db/trait_level_effects_tables/zzz_cbfm_metal_wom_cost_fix.tsv
@@ -1,0 +1,3 @@
+trait_level	effect	effect_scope	value
+#trait_level_effects_tables;0;db/trait_level_effects_tables/tzeentch_metal_spells_fix			
+wh3_dlc20_legacy_trait_sorcerer_lord_metal_tze_to_daemon_prince	wh2_dlc15_effect_magic_metal_reduce_wom_cost_all	character_to_character_own	-1.0


### PR DESCRIPTION
To match the other ascension traits for spell casting lords, changed wom cost reduction from -10 to -1

With the flat -10, most metal spells were completely free.