### PR TITLE
Fix for #132, Expendable w/ Glamoured

### DIFF
--- a/db/special_ability_phase_attribute_effects_tables/zzz_cbfm_glamoured_expendable_fix.tsv
+++ b/db/special_ability_phase_attribute_effects_tables/zzz_cbfm_glamoured_expendable_fix.tsv
@@ -1,0 +1,4 @@
+attribute	phase	attribute_type
+#special_ability_phase_attribute_effects_tables;1;db/special_ability_phase_attribute_effects_tables/zzz_cbfm_glamoured_expendable_fix		
+expendable	wh2_dlc16_unit_passive_glamoured	positive
+expendable	wh2_dlc16_unit_passive_glamoured_lv2	positive


### PR DESCRIPTION
This turned out to be much simpler than I thought. As an added bonus, the Expendable attribute no longer shows up as a negative in WH3, which accurately reflects the fact that it's actually more of a net benefit.

![image](https://user-images.githubusercontent.com/112144702/192930450-51fc7141-b3aa-4f99-b318-2f3f90263972.png)

Fixes #132 