### PR TITLE
Fix for #523, apply Morghur's Ardour of Fury to army; matching skill description

### DIFF
--- a/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_morghur_ardour_of_fury_fix.tsv
+++ b/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_morghur_ardour_of_fury_fix.tsv
@@ -1,0 +1,3 @@
+character_skill_key	effect_key	level	effect_scope	value
+#character_skill_level_to_effects_junctions_tables;1;db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_morghur_ardour_of_fury_fix				
+wh_dlc03_skill_bst_morghur_unique_primal_fury	wh_dlc03_effect_ability_enable_primal_fury	1	general_to_force_own	5.0000


### PR DESCRIPTION
Related to #523 

This fix changes Morghur's Ardour of Fury skill's campaign effect scope to "general_to_force_own", which matches the value in Warhammer II. Every unit in Morghur's army now gets the base Primal Fury effect, instead of just Morghur himself; which matches the skill description.

Units don't get Primal Fury Upgraded when the "Primal Fury" dark challenge is completed, but the upgrade still works for units that have the effect innately. I don't know the pack file structure well enough to give the upgrade to all units in the army, and I'm not sure that's what the developers intended.

In unmodified Warhammer III, the Ardour of Fury skill is set as "character_to_character_own_armytext":
```
TABLE = {
	["wh_dlc03_skill_bst_morghur_unique_primal_fury"] = { ["character_skill_key"] = "wh_dlc03_skill_bst_morghur_unique_primal_fury", ["effect_key"] = "wh_dlc03_effect_ability_enable_primal_fury", ["level"] = 1, ["effect_scope"] = "character_to_character_own_armytext", ["value"] = 5 }
}
```
Contrary to the name, this campaign effect scope exactly matches the "character_to_character" scope and has no effect on the army:
```
TABLE = {
	["character_to_character_own"] = { ["key"] = "character_to_character_own", ["location"] = "character", ["ownership"] = "yours", ["source"] = "character", ["target"] = "character", ["territory"] = "any" },
	["character_to_character_own_armytext"] = { ["key"] = "character_to_character_own_armytext", ["location"] = "character", ["ownership"] = "yours", ["source"] = "character", ["target"] = "character", ["territory"] = "any" }
}
```
Compared to:
```
TABLE = {
	["general_to_force_own"] = { ["key"] = "general_to_force_own", ["location"] = "forcewide_when_commanding", ["ownership"] = "yours", ["source"] = "character", ["target"] = "force", ["territory"] = "any" }
}
```