### PR TITLE
Fix for #801

### DIFF
--- a/script/campaign/wh3_main_combi/mod/zzz_cbfm_player_vow_fixes.lua
+++ b/script/campaign/wh3_main_combi/mod/zzz_cbfm_player_vow_fixes.lua
@@ -2,7 +2,7 @@ local function init()
     core:remove_listener("character_completed_battle_pledge_to_campaign")
     core:add_listener(
 	"character_completed_battle_pledge_to_campaign",
-   "CharacterCompletedBattle",
+	"CharacterCompletedBattle",
 	function(context)
 		local pb = context:pending_battle()
 		local battle_type = pb:battle_type()
@@ -58,6 +58,74 @@ local function init()
 	end,
 	true
 	)
+	
+	-- added fix for ai lords skipping vows when gaining multiple levels in one turn, which is a new thing in wh3. much of this is based on a different fix from sm0kin in the wh2 days
+	local knights_protection = 
+	{
+		"wh_dlc07_trait_brt_knights_vow_knowledge_pledge", 
+		"wh_dlc07_trait_brt_knights_vow_order_pledge",
+		"wh_dlc07_trait_brt_knights_vow_chivalry_pledge",
+		"wh_dlc07_trait_brt_protection_troth_knowledge_pledge",
+		"wh_dlc07_trait_brt_protection_troth_order_pledge",
+		"wh_dlc07_trait_brt_protection_troth_chivalry_pledge"
+	}
+	local questing_wisdom = 
+	{
+		"wh_dlc07_trait_brt_questing_vow_campaign_pledge",
+		"wh_dlc07_trait_brt_questing_vow_heroism_pledge",
+		"wh_dlc07_trait_brt_questing_vow_protect_pledge",
+		"wh_dlc07_trait_brt_wisdom_troth_campaign_pledge",
+		"wh_dlc07_trait_brt_wisdom_troth_heroism_pledge",
+		"wh_dlc07_trait_brt_wisdom_troth_protect_pledge"
+	}
+	local grail_virtue = 
+	{
+		"wh_dlc07_trait_brt_grail_vow_untaint_pledge",
+		"wh_dlc07_trait_brt_grail_vow_valour_pledge",
+		"wh_dlc07_trait_brt_grail_vow_destroy_pledge",
+		"wh_dlc07_trait_brt_virtue_troth_untaint_pledge",
+		"wh_dlc07_trait_brt_virtue_troth_valour_pledge",
+		"wh_dlc07_trait_brt_virtue_troth_destroy_pledge"
+	}
+	
+	local function has_pledge(character,pledge_table)
+		for i = 1, #pledge_table do
+			if character:has_trait(pledge_table[i]) then 
+				return true
+			end
+		end  
+		return false
+	end
+	
+	core:remove_listener("character_rank_up_vows_per_level_ai")
+	core:add_listener(
+	"character_rank_up_vows_per_level_ai",
+	"CharacterRankUp",
+	true,
+	function(context)
+		local character = context:character()
+		local faction = character:faction()
+		
+		if not faction:is_human() and faction:culture() == "wh_main_brt_bretonnia" and character:character_type("general") then
+			local rank = character:rank()
+			
+			if rank >= 2 and not has_pledge(character,knights_protection) then
+				for i = 1, 6 do
+					add_vow_progress(character, "wh_dlc07_trait_brt_knights_vow_knowledge_pledge", true, false)
+				end
+			elseif rank >= 5 and not has_pledge(character,questing_wisdom) then
+				for i = 1, 6 do
+					add_vow_progress(character, "wh_dlc07_trait_brt_questing_vow_protect_pledge", true, false)
+				end
+			elseif rank == 10 and not has_pledge(character,grail_virtue) then
+				for i = 1, 6 do
+					add_vow_progress(character, "wh_dlc07_trait_brt_grail_vow_valour_pledge", true, false)
+				end
+			end
+		end
+	end,
+	true
+)
 end
 
 cm:add_post_first_tick_callback(init)

--- a/script/campaign/wh3_main_combi/mod/zzz_cbfm_player_vow_fixes.lua
+++ b/script/campaign/wh3_main_combi/mod/zzz_cbfm_player_vow_fixes.lua
@@ -117,7 +117,7 @@ local function init()
 				for i = 1, 6 do
 					add_vow_progress(character, "wh_dlc07_trait_brt_questing_vow_protect_pledge", true, false)
 				end
-			elseif rank == 10 and not has_pledge(character,grail_virtue) then
+			elseif rank >= 10 and not has_pledge(character,grail_virtue) then
 				for i = 1, 6 do
 					add_vow_progress(character, "wh_dlc07_trait_brt_grail_vow_valour_pledge", true, false)
 				end


### PR DESCRIPTION
This changes the requirements for automatic vows to be given at any level above a certain threshold rather than only at particular levels. A trait check is added to ensure there are no duplicates.

This fixes #801