### PR TITLE
Fix for #830 , Rogue idol double dip phys res

### DIFF
--- a/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_wurrzag_rogue_idol_fix_effectjunction.tsv
+++ b/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_wurrzag_rogue_idol_fix_effectjunction.tsv
@@ -1,0 +1,3 @@
+character_skill_key	effect_key	level	effect_scope	value
+#character_skill_level_to_effects_junctions_tables;1;db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_wurrzag_rogue_idol_fix_effectjunction				
+wh2_dlc15_skill_unique_grn_wurrzag_colossal_warpaint	wurrzag_phys_res_monsters	1	general_to_force_own_unseen	-20.0000

--- a/db/effect_bonus_value_ids_unit_sets_tables/zzz_cbfm_wurrzag_rogue_idol_fix_unitsettable.tsv
+++ b/db/effect_bonus_value_ids_unit_sets_tables/zzz_cbfm_wurrzag_rogue_idol_fix_unitsettable.tsv
@@ -1,0 +1,3 @@
+bonus_value_id	effect	unit_set
+#effect_bonus_value_ids_unit_sets_tables;0;db/effect_bonus_value_ids_unit_sets_tables/zzz_cbfm_wurrzag_rogue_idol_fix_unitsettable		
+unit_damage_resistance_physical_mod	wurrzag_phys_res_monsters	wurrzag_colossal_warpaint

--- a/db/effects_tables/zzz_cbfm_wurrzag_rogue_idol_fix_effecttable.tsv
+++ b/db/effects_tables/zzz_cbfm_wurrzag_rogue_idol_fix_effecttable.tsv
@@ -1,0 +1,3 @@
+effect	icon	priority	icon_negative	category	is_positive_value_good
+#effects_tables;0;db/effects_tables/zzz_cbfm_wurrzag_rogue_idol_fix_effecttable					
+wurrzag_phys_res_monsters		0		battle	true

--- a/db/unit_set_to_unit_junctions_tables/zzz_cbfm_wurrzag_rogue_idol_fix_unitsettojunction.tsv
+++ b/db/unit_set_to_unit_junctions_tables/zzz_cbfm_wurrzag_rogue_idol_fix_unitsettojunction.tsv
@@ -1,0 +1,4 @@
+unit_caste	unit_category	unit_class	unit_record	unit_set	exclude
+#unit_set_to_unit_junctions_tables;1;db/unit_set_to_unit_junctions_tables/zzz_cbfm_wurrzag_rogue_idol_fix_unitsettojunction					
+			wh2_dlc15_grn_mon_rogue_idol_0	wurrzag_colossal_warpaint	false
+			wh2_dlc15_grn_mon_rogue_idol_ror_0	wurrzag_colossal_warpaint	false

--- a/db/unit_sets_tables/zzz_cbfm_wurrzag_rogue_idol_fix_unitset.tsv
+++ b/db/unit_sets_tables/zzz_cbfm_wurrzag_rogue_idol_fix_unitset.tsv
@@ -1,0 +1,3 @@
+key	use_unit_exp_level_range	min_unit_exp_level_inclusive	max_unit_exp_level_inclusive	special_category
+#unit_sets_tables;2;db/unit_sets_tables/zzz_cbfm_wurrzag_rogue_idol_fix_unitset				
+wurrzag_colossal_warpaint	false	-1	-1	


### PR DESCRIPTION
Adds a new effect that negates the double 20% phys res that Rogue Idol gets