### PR TITLE
Fix for #886 - Oxyotl's defeat trait not appearing

### DIFF
--- a/db/character_traits_tables/zzz_cbfm_oxy_defeat_trait_fix.tsv
+++ b/db/character_traits_tables/zzz_cbfm_oxy_defeat_trait_fix.tsv
@@ -1,0 +1,3 @@
+key	no_going_back_level	hidden	precedence	icon	ui_priority	pre_battle_speech_parameter
+#character_traits_tables;2;db/character_traits_tables/cbfm_character_traits_tables_oxy_trait						
+wh2_dlc17_trait_defeated_oxyotl	1	false	1	lizardmen	1	


### PR DESCRIPTION
Fixes Oxyotl's defeat trait erroneously being set to hidden.