### PR TITLE
Fix for issue #903 , Kroxi rite

### DIFF
--- a/db/effect_bonus_value_ids_unit_sets_tables/zzz_cbfm_kroxi_rite_fix.tsv
+++ b/db/effect_bonus_value_ids_unit_sets_tables/zzz_cbfm_kroxi_rite_fix.tsv
@@ -1,0 +1,3 @@
+bonus_value_id	effect	unit_set
+#effect_bonus_value_ids_unit_sets_tables;0;db/effect_bonus_value_ids_unit_sets_tables/zzz_cbfm_kroxi_rite_fix		
+melee_damage_ap_mod_mult	wh2_dlc13_effect_weapon_damage_lzd_kroxigors_sacred_kroxigors	lzd_kroxigor


### PR DESCRIPTION
Adds melee_damage_ap_mod_mult to Nakais rite increasing weapon strength for kroxigors, since they have so low base damage values they barely got a buff from using the rite.