### PR TITLE
Fix for issue #958

### DIFF
--- a/db/effect_bonus_value_ids_unit_sets_tables/zzz_tzeentchtech.tsv
+++ b/db/effect_bonus_value_ids_unit_sets_tables/zzz_tzeentchtech.tsv
@@ -1,0 +1,4 @@
+bonus_value_id	effect	unit_set
+#effect_bonus_value_ids_unit_sets_tables;0;db/effect_bonus_value_ids_unit_sets_tables/zzz_tzeentchtech		
+armour_mod	wh3_dlc20_effect_armour_tze_marauders	merc_set_chs_marauder_horsemen_tze
+armour_mod	wh3_main_effect_force_stat_armour_tze_knights	chosen_mtze


### PR DESCRIPTION
Fixes the tzeentch techs "Gift of mutation" not giving +10 armor to horsemen of tzeentch and "Metallurgical Morphism" not giving +10 armor to chosen of tzeentch.