### PR TITLE
Fix for issue #534 , Handmaiden quicksilver ability missing

### DIFF
--- a/db/unit_abilities_tables/zzz_cbfm_handmaiden_quicksilver.tsv
+++ b/db/unit_abilities_tables/zzz_cbfm_handmaiden_quicksilver.tsv
@@ -1,0 +1,3 @@
+key	requires_effect_enabling	icon_name	overpower_option	type	video	uniqueness	is_unit_upgrade	is_hidden_in_ui	source_type	superseded_abilities_set	is_hidden_in_ui_for_enemy
+#unit_abilities_tables;17;db/unit_abilities_tables/zzz_cbfm_handmaiden_quicksilver											
+wh2_dlc10_hero_passive_quicksilver_shot	false	wh2_dlc10_hero_passive_quicksilver_shot		wh_type_area_of_augments		wh_main_anc_group_common	true	false	passive		false


### PR DESCRIPTION
Just unticked require effect enabling so the passive is available in campaign