### PR TITLE
Fix for issue #986 , Lord of torment

### DIFF
--- a/db/special_ability_intensity_settings_tables/zzz_cbfm_lord_of_torment.tsv
+++ b/db/special_ability_intensity_settings_tables/zzz_cbfm_lord_of_torment.tsv
@@ -1,0 +1,3 @@
+ability	default_amount	max_amount	inverse	intensity_source	intensity_type
+#special_ability_intensity_settings_tables;2;db/special_ability_intensity_settings_tables/zzz_cbfm_lord_of_torment					
+wh3_main_lord_passive_lord_of_torment	0.0000	8.0000	false	enemy_in_range_low_morale	linear_multiplier


### PR DESCRIPTION
Changes intensity from 80 to 8 so the Lord of torment works properly and gives bigger heals. (80 units is what's needed for full intensity currently, which is almost impossible)