### PR TITLE
Fix for issue #982 , Channeller innate for tomb kings

### DIFF
--- a/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_channellerfix.tsv
+++ b/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_channellerfix.tsv
@@ -1,0 +1,3 @@
+character_skill_key	effect_key	level	effect_scope	value
+#character_skill_level_to_effects_junctions_tables;1;db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_channellerfix				
+wh2_dlc09_skill_innate_tmb_channeller	wh3_main_effect_winds_of_magic_pool_cap	1	character_to_force_own_unseen	6.0000


### PR DESCRIPTION
Changes scope for liche priest so that the army get the 6+ magic reserves from the innate ability "Channeller"

Fixes #982 