### PR TITLE
Fix for issue #1008 , Exclude chariots from chs_warriors set

### DIFF
--- a/db/unit_set_to_unit_junctions_tables/zzz_cbfm_slachariot_exclude.tsv
+++ b/db/unit_set_to_unit_junctions_tables/zzz_cbfm_slachariot_exclude.tsv
@@ -1,0 +1,3 @@
+unit_caste	unit_category	unit_class	unit_record	unit_set	exclude
+#unit_set_to_unit_junctions_tables;1;db/unit_set_to_unit_junctions_tables/zzz_cbfm_slachariot_exclude					
+			wh3_dlc20_chs_cav_chaos_chariot_msla_ror	chs_warriors	true


### PR DESCRIPTION
So they don't get hit by buffs that's intended for chaos warriors

Fixes #1008 