### PR TITLE
Fix for issue #1018 , regen plague drones

### DIFF
--- a/db/unit_set_unit_ability_junctions_tables/zzz_cbfm_pigbarter_plaguedrones.tsv
+++ b/db/unit_set_unit_ability_junctions_tables/zzz_cbfm_pigbarter_plaguedrones.tsv
@@ -1,0 +1,3 @@
+key	unit_ability	unit_set
+#unit_set_unit_ability_junctions_tables;0;db/unit_set_unit_ability_junctions_tables/zzz_cbfm_pigbarter_plaguedrones		
+wh3_dlc20_effect_ability_regeneration_rot_flies	wh_main_unit_passive_regeneration	nur_plague_drones_rot_flies


### PR DESCRIPTION
Don't know if intended or not, but the other effects of pigbarter affects both types of flies so i vote for adding plague drones to the regen effect.