### PR TITLE
Fix for issue #1050, Intoxicating presence trait scope

### DIFF
--- a/db/trait_level_effects_tables/zzz_cbfm_intoxicating_scope.tsv
+++ b/db/trait_level_effects_tables/zzz_cbfm_intoxicating_scope.tsv
@@ -1,0 +1,3 @@
+trait_level	effect	effect_scope	value
+#trait_level_effects_tables;0;db/trait_level_effects_tables/zzz_cbfm_intoxicating_scope			
+wh3_main_trait_dilemma_sla_intoxicating_presence	wh_main_effect_force_stat_leadership	character_to_force_own	6.0000

--- a/db/trait_level_effects_tables/zzz_cbfm_intoxicating_scope.tsv
+++ b/db/trait_level_effects_tables/zzz_cbfm_intoxicating_scope.tsv
@@ -1,3 +1,4 @@
 trait_level	effect	effect_scope	value
 #trait_level_effects_tables;0;db/trait_level_effects_tables/zzz_cbfm_intoxicating_scope			
 wh3_main_trait_dilemma_sla_intoxicating_presence	wh_main_effect_force_stat_leadership	character_to_force_own	6.0000
+wh3_main_trait_dilemma_sla_intoxicating_presence	wh_main_effect_force_stat_leadership	general_to_force_own	0.0000


### PR DESCRIPTION
This trait can only, from what i can see, be received by heroes. Changing the scope to character_to_force_own