### PR TITLE
Fix for issue #1537 , Magic item find scopes

### DIFF
--- a/db/ancillary_to_effects_tables/zzz_cbfm_magic_find_traits.tsv
+++ b/db/ancillary_to_effects_tables/zzz_cbfm_magic_find_traits.tsv
@@ -1,0 +1,3 @@
+ancillary	effect	effect_scope	value
+#ancillary_to_effects_tables;0;db/ancillary_to_effects_tables/zzz_cbfm_magic_find_traits			
+wh2_main_anc_follower_lzd_artefact_hunter	wh_main_effect_character_mod_ancillary_drop	agent_to_parent_army_general_own	10.0000

--- a/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_magic_find_traits.tsv
+++ b/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_magic_find_traits.tsv
@@ -1,0 +1,3 @@
+character_skill_key	effect_key	level	effect_scope	value
+#character_skill_level_to_effects_junctions_tables;1;db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_magic_find_traits				
+wh2_main_skill_innate_hef_loremaster_army_7_exhilerated	wh_main_effect_character_mod_ancillary_drop	1	agent_to_parent_army_general_own	25.0000

--- a/db/trait_level_effects_tables/zzz_cbfm_magic_find_traits.tsv
+++ b/db/trait_level_effects_tables/zzz_cbfm_magic_find_traits.tsv
@@ -1,0 +1,3 @@
+trait_level	effect	effect_scope	value
+#trait_level_effects_tables;0;db/trait_level_effects_tables/zzz_cbfm_magic_find_traits			
+wh2_dlc17_trait_unique_loracle	wh_main_effect_character_mod_ancillary_drop	agent_to_parent_army_general_own	15.0000


### PR DESCRIPTION
Changes scopes for some ancillaries, traits and skills to accompanying lord instead of it just being directed to the character itself so it works