### PR TITLE
Fix for #393, Greenskin AI using Waaagh abilities in battle

### DIFF
--- a/script/battle/mod/zzz_cbfm_ai_waaagh.lua
+++ b/script/battle/mod/zzz_cbfm_ai_waaagh.lua
@@ -1,0 +1,50 @@
+local waaagh_list =
+{
+	"wh2_dlc15_army_abilities_azhags_big_waaagh",
+	"wh2_dlc15_army_abilities_azhags_waaagh",
+	"wh2_dlc15_army_abilities_big_waaagh",
+	"wh2_dlc15_army_abilities_grimgors_big_waaagh",
+	"wh2_dlc15_army_abilities_grimgors_waaagh",
+	"wh2_dlc15_army_abilities_groms_big_waaagh",
+	"wh2_dlc15_army_abilities_groms_waaagh",
+	"wh2_dlc15_army_abilities_skarsniks_big_waaagh",
+	"wh2_dlc15_army_abilities_skarsniks_waaagh",
+	"wh2_dlc15_army_abilities_waaagh",
+	"wh2_dlc15_army_abilities_wurrzags_big_waaagh",
+	"wh2_dlc15_army_abilities_wurrzags_waaagh"
+}
+
+waaagh_use_table = {}
+waaagh_active_table = {}
+waaagh_army_unit_counts = {}
+
+local function fire_waaagh(army,army_id_str)
+	for i = 1, #waaagh_list do		
+		army:use_special_ability(waaagh_list[i],v(0,0,0)) -- only the waaagh ability this army actually has will be used
+	end
+	--army:reset_currency_amount("army_ability_bar_fill") -- this needs to be reset in script for AI, which is... interesting. also, this command doesn't work, hence the reason for this time delay scheme
+	waaagh_use_table[army_id_str] = waaagh_use_table[army_id_str] * 2
+	waaagh_active_table[army_id_str] = false
+end
+
+local function waaagh_loop()
+	for _, alliance in model_pairs(bm:alliances()) do
+		for _, army in model_pairs(alliance:armies()) do
+			if army:subculture_key() == "wh_main_sc_grn_greenskins" and not army:is_player_controlled() then
+				local army_id_str = tostring(army:unique_id())
+				
+				if not waaagh_use_table[army_id_str] then waaagh_use_table[army_id_str] = 1 end -- set a unique counter for this army to 1 if it hasn't been generated yet
+				if not waaagh_army_unit_counts[army_id_str] then waaagh_army_unit_counts[army_id_str] = army:units():count() end -- saving this once here at the beginning so the value doesn't change as units get killed or rout
+				
+				local points_required = 250 * waaagh_army_unit_counts[army_id_str] * waaagh_use_table[army_id_str] - 1 -- -1 to prevent rounding errors
+				if army:currency_amount("army_ability_bar_fill") >= points_required and not waaagh_active_table[army_id_str] then
+					local delay = 20000 * (waaagh_use_table[army_id_str] - 1) -- first waaagh has no delay, then 20 seconds per level (levels double each time, so :20 > 1:00 > 2:20 > 5:00)
+					waaagh_active_table[army_id_str] = true
+					bm:callback(function() fire_waaagh(army,army_id_str) end,delay)
+				end
+			end
+		end
+	end
+end
+
+bm:repeat_callback(waaagh_loop,3000,"waaagh_callback")


### PR DESCRIPTION
Battle script solution for AI Waaagh abilities, fixes #393 

Note that there are some band-aid aspects to this:
- In testing, I realized that that triggering the ability via script does not reset the army ability counter as pressing the button does for the player, and while the documentation provides a way to reset this counter via script (`army:reset_currency_amount`), this function doesn't appear to work. 
- This essentially means that the AI gets a head start on the counter for each subsequent Waaagh usage (the total requirement increases the same as for the player, but they start where the left off rather than back at 0 like the player). To counteract this, I've added a progressive time delay to the ability usage for the AI that goes up with each Waaagh use at a level commensurate with the increase in ability use cost (0 seconds for first use, then +20 seconds, +60 seconds, +2:20, +5:00).
- The AI still needs to meet the ability points threshold first (fueled in the case of Waaagh abilities by units being engaged in melee); the delay is then added after hitting that point.
- In my testing with Greenskin vs. Greenskin mirrors, this system with these delays seems to largely match player availability. It's exactly the same for the first use, very close for the second and third, and the fourth is rarely ever reached, anyway (the fifth was never reached in my testing). 

Anyway, please test.