### PR TITLE
Fix for issue #1569 , Gyrobombers remove wounds

### DIFF
--- a/db/land_units_to_unit_abilites_junctions_tables/zzz_cbfm_removewounds_gyrobombers.tsv
+++ b/db/land_units_to_unit_abilites_junctions_tables/zzz_cbfm_removewounds_gyrobombers.tsv
@@ -1,0 +1,4 @@
+ability	land_unit
+#land_units_to_unit_abilites_junctions_tables;0;db/land_units_to_unit_abilites_junctions_tables/zzz_cbfm_removewounds_gyrobombers	
+remove_wounds	wh_main_dwf_veh_gyrobomber
+remove_wounds	wh_dlc06_dwf_veh_skyhammer_0

--- a/db/unit_abilities_tables/zzz_cbfm_removewounds_gyrobombers.tsv
+++ b/db/unit_abilities_tables/zzz_cbfm_removewounds_gyrobombers.tsv
@@ -1,0 +1,3 @@
+key	requires_effect_enabling	icon_name	overpower_option	type	video	uniqueness	is_unit_upgrade	is_hidden_in_ui	source_type	superseded_abilities_set	is_hidden_in_ui_for_enemy
+#unit_abilities_tables;17;db/unit_abilities_tables/zzz_cbfm_removewounds_gyrobombers											
+remove_wounds	true			wh_type_hex		wh_main_anc_group_common	false	false	passive	wounds_remove	false

--- a/db/unit_ability_superseded_abilities_set_elements_tables/zzz_cbfm_removewounds_gyrobombers.tsv
+++ b/db/unit_ability_superseded_abilities_set_elements_tables/zzz_cbfm_removewounds_gyrobombers.tsv
@@ -1,0 +1,3 @@
+set_key	superseded_ability_key
+#unit_ability_superseded_abilities_set_elements_tables;0;db/unit_ability_superseded_abilities_set_elements_tables/zzz_cbfm_removewounds_gyrobombers	
+wounds_remove	wh3_main_unit_passive_single_entity

--- a/db/unit_ability_superseded_abilities_sets_tables/zzz_cbfm_removewounds_gyrobombers.tsv
+++ b/db/unit_ability_superseded_abilities_sets_tables/zzz_cbfm_removewounds_gyrobombers.tsv
@@ -1,0 +1,3 @@
+key
+#unit_ability_superseded_abilities_sets_tables;0;db/unit_ability_superseded_abilities_sets_tables/zzz_cbfm_removewounds_gyrobombers
+wounds_remove

--- a/text/db/!cbfm_skyhammers.loc.tsv
+++ b/text/db/!cbfm_skyhammers.loc.tsv
@@ -1,0 +1,3 @@
+key	text	tooltip
+#Loc;1;text/db/!cbfm_skyhammers.loc		
+land_units_onscreen_name_wh_dlc06_dwf_veh_skyhammer_0	Skyhammers (Gyrobombers)	false


### PR DESCRIPTION
Thanks to JvJ i superseded the wound ability on both gyrobomber units with a hidden effect doing nothing. Also added LOC that changes gyrobomber ror to gyrobombers (Plural)