### PR TITLE
Fix for issue #1596, nurgle lord not devoted

### DIFF
--- a/db/effect_bonus_value_agent_subtype_junctions_tables/zzz_cbfm_nurgle_devoted_lord.tsv
+++ b/db/effect_bonus_value_agent_subtype_junctions_tables/zzz_cbfm_nurgle_devoted_lord.tsv
@@ -1,0 +1,3 @@
+bonus_value_id	effect	subtype
+#effect_bonus_value_agent_subtype_junctions_tables;0;db/effect_bonus_value_agent_subtype_junctions_tables/zzz_cbfm_nurgle_devoted_lord		
+melee_defence_mod_mult	wh3_dlc20_effect_melee_defence_nurgle_armies	wh3_dlc25_chs_lord_mnur


### PR DESCRIPTION
Makes it so chaos lord of nurgle benefits from gift of chaos buffing nurgle devoted armies