### PR TITLE
Fix for issue #1643 , cannon unit sets

### DIFF
--- a/db/unit_set_to_unit_junctions_tables/zzz_cbfm_malakai_cannons.tsv
+++ b/db/unit_set_to_unit_junctions_tables/zzz_cbfm_malakai_cannons.tsv
@@ -1,0 +1,4 @@
+unit_caste	unit_category	unit_class	unit_record	unit_set	exclude
+#unit_set_to_unit_junctions_tables;1;db/unit_set_to_unit_junctions_tables/zzz_cbfm_malakai_cannons					
+			wh_main_dwf_art_cannon_malakai	wh2_dlc11_dwf_bolt_throwers_grudge_thrower_cannon_organ_gun_goblin_hewer	false
+			wh_main_dwf_art_cannon_malakai	wh2_dlc11_dwf_irondrakes_flame_cannon	true


### PR DESCRIPTION
Remove malakai cannons from flame cannon red line buff and adds them to their correct place. Let me know if i missed any and i can just add to this