### PR TITLE
Fix for issue #1709 , Will of the patriarch

### DIFF
--- a/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_gelt_magerecruit.tsv
+++ b/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_gelt_magerecruit.tsv
@@ -1,0 +1,3 @@
+character_skill_key	effect_key	level	effect_scope	value
+#character_skill_level_to_effects_junctions_tables;1;db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_gelt_magerecruit				
+wh_dlc08_skill_emp_lord_unique_balthasar_unique_4	wh_main_effect_agent_recruitment_xp_wizard_empire	1	character_to_province_own_factionwide	2.0000


### PR DESCRIPTION
Changes scope so wizard recruited from both gelts mechanic and regular recruitment are the same rank