### PR TITLE
Fix for issue #1800, Mastery of the Elemental Winds for mounted Jade Wizards

### DIFF
--- a/db/unit_set_to_unit_junctions_tables/zzz_cbfm_jade_mastery_pegasus.tsv
+++ b/db/unit_set_to_unit_junctions_tables/zzz_cbfm_jade_mastery_pegasus.tsv
@@ -1,0 +1,3 @@
+unit_caste	unit_category	unit_class	unit_record	unit_set	exclude
+#unit_set_to_unit_junctions_tables;1;db/unit_set_to_unit_junctions_tables/zzz_cbfm_jade_mastery_pegasus					
+			wh_dlc05_emp_cha_wizard_life_3	emp_wizards	false


### PR DESCRIPTION
Gives jade wizards on pegasus mastery of the elemental winds