### PR TITLE
Fix for #1759, Restock for Jorek Grimm

### DIFF
--- a/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_jorek_grimm_restock.tsv
+++ b/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_jorek_grimm_restock.tsv
@@ -1,0 +1,3 @@
+character_skill_key	effect_key	level	effect_scope	value
+#character_skill_level_to_effects_junctions_tables;1;db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_jorek_grimm_restock				
+wh2_dlc13_skill_all_dummy_agent_actions_hunter_jorek	wh2_dlc17_effect_ability_enable_restock	1	character_to_character_own	1.0000


### PR DESCRIPTION
Adds the effect enabling Restock to Jorek's hidden agent actions skill (same thing that is done for Dwarf Master Engineer)

Fixes #1759 