### PR TITLE
Fix for issue #1912 , Prize hunter and itzl

### DIFF
--- a/db/unit_set_to_unit_junctions_tables/zzz_cbfm_itzl_prize_hunter.tsv
+++ b/db/unit_set_to_unit_junctions_tables/zzz_cbfm_itzl_prize_hunter.tsv
@@ -1,0 +1,9 @@
+unit_caste	unit_category	unit_class	unit_record	unit_set	exclude
+#unit_set_to_unit_junctions_tables;1;db/unit_set_to_unit_junctions_tables/zzz_cbfm_itzl_prize_hunter					
+			wh2_dlc12_lzd_cav_ripperdactyl_riders_0	lzd_beasts	false
+			wh2_dlc12_lzd_cav_ripperdactyl_riders_ror_0	lzd_beasts	false
+			wh2_dlc12_lzd_mon_ancient_salamander_0	lzd_beasts	false
+			wh2_dlc12_lzd_mon_salamander_pack_0	lzd_beasts	false
+			wh2_dlc12_lzd_mon_salamander_pack_ror_0	lzd_beasts	false
+			wh2_dlc13_lzd_mon_razordon_pack_0	lzd_beasts	false
+			wh2_dlc13_lzd_mon_razordon_pack_ror_0	lzd_beasts	false

--- a/text/db/!cbfm_itzlprize.loc.tsv
+++ b/text/db/!cbfm_itzlprize.loc.tsv
@@ -1,0 +1,3 @@
+key	text	tooltip
+#Loc;1;text/db/!cbfm_itzlprize.loc		
+effects_description_wh2_main_effect_upkeep_cost_reduction_lzd_beasts	Upkeep: %+n% for Beasts, Terradon Riders, Ripperdactyl riders and Cold One Cavalry units	false


### PR DESCRIPTION
I added missing DLC units with the reasoning that there's no real theme with terradon riders getting both buffs but not ripperdactyls. The same goes for Nakai's Itzl buffs, makes no sense that just a few dlc units gets left out of the buffs