### PR TITLE
Fix for #2108, "Magic Feaster" Big Name

### DIFF
--- a/script/campaign/mod/zzz_cbfm_initiative_fixes.lua
+++ b/script/campaign/mod/zzz_cbfm_initiative_fixes.lua
@@ -19,6 +19,44 @@ function cbfm_update_initiatives()
 				["grant_immediately"] = true 
 			}
 		end
+		-- "Magic Feaster" Big Name fix
+		if value.initiative_key == "wh3_dlc26_character_initiative_ogr_big_name_magic_feaster" then
+			initiative_templates[key] =
+			{
+				["initiative_key"] = "wh3_dlc26_character_initiative_ogr_big_name_magic_feaster",
+				["event"] = {"CharacterCompletedBattle", "HeroCharacterParticipatedInBattle"},
+				["condition"] =
+					function(context)
+						local character = context:character()
+						
+						local pb = cm:model():pending_battle()
+						local attack_force = pb:attacker():military_force()
+						local defense_force = pb:defender():military_force()
+						local hero_attacker = false
+						local hero_defender = false
+						
+						for _, check_char in model_pairs(attack_force:character_list()) do
+							if check_char == character then
+								hero_attacker = true
+								break
+							end
+						end
+						
+						for _, check_char in model_pairs(defense_force:character_list()) do
+							if check_char == character then
+								hero_defender = true
+								break
+							end
+						end
+						
+						if character:won_battle() then
+							--local pb = cm:model():pending_battle()
+							return (pb:has_attacker() and (pb:attacker() == character or hero_attacker) and cm:get_saved_value("big_name_defender_spellcaster")) or (pb:has_defender() and (pb:defender() == character or hero_defender) and cm:get_saved_value("big_name_attacker_spellcaster"))
+						end
+					end,
+				["grant_immediately"] = true
+			}
+		end
 	end
 end
 


### PR DESCRIPTION
This allows hero units to gain the "Magic Feaster" big name, which is the only one of the reported Big Name bugs I could find in the code.

Fixes #2108 