### PR TITLE
Fix for issue #2133 , Savage orc skinsacks

### DIFF
--- a/db/unit_purchasable_effect_sets_tables/zzz_cbfm_savage_arrer_scrap.tsv
+++ b/db/unit_purchasable_effect_sets_tables/zzz_cbfm_savage_arrer_scrap.tsv
@@ -1,0 +1,3 @@
+unit	purchasable_effect	is_exclusive
+#unit_purchasable_effect_sets_tables;0;db/unit_purchasable_effect_sets_tables/zzz_cbfm_savage_arrer_scrap		
+wh_main_grn_inf_savage_orc_arrer_boyz	wh2_dlc15_grn_upgrade_combat_ammobag	false

--- a/db/unit_set_to_unit_junctions_tables/zzz_cbfm_savage_arrer_scrap.tsv
+++ b/db/unit_set_to_unit_junctions_tables/zzz_cbfm_savage_arrer_scrap.tsv
@@ -1,0 +1,3 @@
+unit_caste	unit_category	unit_class	unit_record	unit_set	exclude
+#unit_set_to_unit_junctions_tables;1;db/unit_set_to_unit_junctions_tables/zzz_cbfm_savage_arrer_scrap					
+			wh_main_grn_inf_savage_orc_arrer_boyz	tech_grn_scrap_3	false


### PR DESCRIPTION
Adds the scrap upgrade to savage orc archers as well, since they're the only missile infantry unit missing this upgrade