### PR TITLE
Fix for issue #2057 , sister swords

### DIFF
--- a/text/db/!cbfm_deathanddoomsinger.loc.tsv
+++ b/text/db/!cbfm_deathanddoomsinger.loc.tsv
@@ -1,0 +1,3 @@
+key	text	tooltip
+#Loc;1;text/db/!cbfm_deathanddoomsinger.loc		
+character_trait_levels_explanation_text_wh3_trait_sister_swords_1	Gained from equipping {{tr:weapon_cynatcian}} and {{tr:weapon_elthraician}}	false


### PR DESCRIPTION
Changed the description so it doesn't say Deathsinger twice. Not tested, but it probably works.