### PR TITLE
Fix for issue #2137 , Skulltaker mass on juggernaut

### DIFF
--- a/db/mounts_tables/zzz_cbfm_skulltaker_mass_mount.tsv
+++ b/db/mounts_tables/zzz_cbfm_skulltaker_mass_mount.tsv
@@ -1,0 +1,3 @@
+key	animation	entity	audio_armour_type	variant	voiceover
+#mounts_tables;10;db/mounts_tables/zzz_cbfm_skulltaker_mass_mount					
+wh3_dlc26_kho_mnt_juggernaut_skulltaker	hq4_wh3_juggernaut	wh3_main_kho_mnt_juggernaut_hero	plate	wh3_dlc26_kho_mnt_juggernaut_skulltaker	vo_culture_Invalid


### PR DESCRIPTION
Changes the entity in mounts_tables to the one all lords and heroes use. Seems to work fine in skirmish battle and the mass is now at 1800. If this isn't the way to change his mass, let me know