### PR TITLE
Fix(ish) for issue #2162 , Snipe slayers

### DIFF
--- a/db/effect_bonus_value_unit_attribute_junctions_tables/zzz_cbfm_snipe_slayer.tsv
+++ b/db/effect_bonus_value_unit_attribute_junctions_tables/zzz_cbfm_snipe_slayer.tsv
@@ -1,0 +1,3 @@
+bonus_value_id	effect	unit_attribute
+#effect_bonus_value_unit_attribute_junctions_tables;0;db/effect_bonus_value_unit_attribute_junctions_tables/zzz_cbfm_snipe_slayer		
+disable	wh2_dlc10_effect_attribute_enable_snipe	slayer


### PR DESCRIPTION
Disables slayer attribute given from snipe. Side effect is that slayer gets disabled if a unit with slayers gets snipe form an item or skill.