### PR TITLE
Fix for issue #2248 , Cockatrice rank 7

### DIFF
--- a/db/unit_sets_tables/zzz_cbfm_bst_cockatrice_buff.tsv
+++ b/db/unit_sets_tables/zzz_cbfm_bst_cockatrice_buff.tsv
@@ -1,0 +1,3 @@
+key	use_unit_exp_level_range	min_unit_exp_level_inclusive	max_unit_exp_level_inclusive	special_category
+#unit_sets_tables;2;db/unit_sets_tables/zzz_cbfm_bst_cockatrice_buff				
+wh3_dlc24_tze_mon_cockatrice_rank7	true	7	9	


### PR DESCRIPTION
Checks level range for beastman rank 7 buffs for the cockatrice