### PR TITLE
Fix for issue #2269 and #2247, spellfire rank 2 buffs

### DIFF
--- a/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_spellfire.tsv
+++ b/db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_spellfire.tsv
@@ -1,0 +1,3 @@
+character_skill_key	effect_key	level	effect_scope	value
+#character_skill_level_to_effects_junctions_tables;1;db/character_skill_level_to_effects_junctions_tables/zzz_cbfm_spellfire				
+wh3_main_skill_all_missile_damage_magic_theme	wh_main_effect_character_stat_missile_damage	2	character_to_character_own	20.0000


### PR DESCRIPTION
Gives 20% damage instead of 10% at rank 2