### PR TITLE
Fix for #2223, Snotling Scavanger drop condition

### DIFF
--- a/script/campaign/mod/zzz_cbfm_follower_fixes.lua
+++ b/script/campaign/mod/zzz_cbfm_follower_fixes.lua
@@ -36,6 +36,21 @@ local followers = {
 				return target_faction:culture() == "wh2_main_hef_high_elves"
 			end,
 		["chance"] = 50
+	},
+
+
+	----------------
+	-- GREENSKINS --
+	----------------
+
+	{
+		["follower"] = "wh_main_anc_follower_greenskins_snotling_scavengers",
+		["event"] = "CharacterSackedSettlement",
+		["condition"] =
+			function(context)
+				return context:character():faction():losing_money();
+			end,
+		["chance"] = 30
 	}
 };
 
@@ -48,22 +63,19 @@ local function cbfm_load_followers()
 			followers[i].condition,
 			function(context)
 				local character = context:character();
-				local chance = followers[i].chance;
-				
-				-- daemon prince shares followers, so has a bigger pool, so the chance is reduced for them
-				if character:faction():culture() == "wh3_main_dae_daemons" then
-					chance = math.round(chance * 0.4);
-				else
-					chance = chance * 0.5;
-				end;
+				local base_chance = followers[i].chance;
+				local drop_chance = calculate_ancillary_drop_chance(character:faction(), followers[i].follower) / 100;
+				local true_chance = base_chance * drop_chance;
 				
 				if core:is_tweaker_set("SCRIPTED_TWEAKER_13") then
-					chance = 100;
-				end;
+					true_chance = 100;
+				end
 				
-				if not character:character_type("colonel") and not character:character_subtype("wh_dlc07_brt_green_knight") and not character:character_subtype("wh2_dlc10_hef_shadow_walker") and cm:random_number(100) <= chance then
-					cm:force_add_ancillary(context:character(), followers[i].follower, false, false);
-				end;
+				if cm:model():random_percent(true_chance) then
+					if not character:character_type("colonel") and not character:character_subtype("wh_dlc07_brt_green_knight") and not character:character_subtype("wh2_dlc10_hef_shadow_walker") then
+						cm:force_add_ancillary(context:character(), followers[i].follower, false, false);
+					end
+				end
 			end,
 			true
 		);


### PR DESCRIPTION
This also contains an update to the follower fixes script in general to match the new way that CA is doing this in 6.2+

Fixes #2223 