### PR TITLE
Fix for issue #2432 , Feral troglodon missing from lzd_beasts set

### DIFF
--- a/db/db/unit_set_to_unit_junctions_tables/zzz_cbfm_blessingitzl.tsv
+++ b/db/db/unit_set_to_unit_junctions_tables/zzz_cbfm_blessingitzl.tsv
@@ -1,6 +1,0 @@
-unit_caste	unit_category	unit_class	unit_record	unit_set	exclude
-#unit_set_to_unit_junctions_tables;1;db/unit_set_to_unit_junctions_tables/zzz_cbfm_blessingitzl					
-			wh2_dlc17_lzd_mon_troglodon_0	lzd_monsters	false
-			wh2_dlc17_lzd_mon_troglodon_ror_0	lzd_monsters	false
-			wh2_dlc17_lzd_mon_troglodon_0	lzd_beasts	false
-			wh2_dlc17_lzd_mon_troglodon_ror_0	lzd_beasts	false

--- a/db/db/unit_set_to_unit_junctions_tables/zzz_cbfm_blessingitzl.tsv
+++ b/db/db/unit_set_to_unit_junctions_tables/zzz_cbfm_blessingitzl.tsv
@@ -1,0 +1,6 @@
+unit_caste	unit_category	unit_class	unit_record	unit_set	exclude
+#unit_set_to_unit_junctions_tables;1;db/unit_set_to_unit_junctions_tables/zzz_cbfm_blessingitzl					
+			wh2_dlc17_lzd_mon_troglodon_0	lzd_monsters	false
+			wh2_dlc17_lzd_mon_troglodon_ror_0	lzd_monsters	false
+			wh2_dlc17_lzd_mon_troglodon_0	lzd_beasts	false
+			wh2_dlc17_lzd_mon_troglodon_ror_0	lzd_beasts	false

--- a/db/unit_set_to_unit_junctions_tables/zzz_cbfm_blessingitzl.tsv
+++ b/db/unit_set_to_unit_junctions_tables/zzz_cbfm_blessingitzl.tsv
@@ -1,0 +1,4 @@
+unit_caste	unit_category	unit_class	unit_record	unit_set	exclude
+#unit_set_to_unit_junctions_tables;1;db/unit_set_to_unit_junctions_tables/zzz_cbfm_blessingitzl					
+			wh2_dlc17_lzd_mon_troglodon_0	lzd_monsters	false
+			wh2_dlc17_lzd_mon_troglodon_ror_0	lzd_monsters	false

--- a/db/unit_set_to_unit_junctions_tables/zzz_cbfm_blessingitzl.tsv
+++ b/db/unit_set_to_unit_junctions_tables/zzz_cbfm_blessingitzl.tsv
@@ -1,4 +1,4 @@
 unit_caste	unit_category	unit_class	unit_record	unit_set	exclude
 #unit_set_to_unit_junctions_tables;1;db/unit_set_to_unit_junctions_tables/zzz_cbfm_blessingitzl					
-			wh2_dlc17_lzd_mon_troglodon_0	lzd_monsters	false
-			wh2_dlc17_lzd_mon_troglodon_ror_0	lzd_monsters	false
+			wh2_dlc17_lzd_mon_troglodon_0	lzd_beasts	false
+			wh2_dlc17_lzd_mon_troglodon_ror_0	lzd_beasts	false


### PR DESCRIPTION
adds troglodon to lzd_monsters