### PR TITLE
Fix for issue #2583, Beorg bonus vs. large

### DIFF
--- a/db/melee_weapons_tables/zzz_cbfm_beorg_antilarge.tsv
+++ b/db/melee_weapons_tables/zzz_cbfm_beorg_antilarge.tsv
@@ -1,0 +1,3 @@
+key	bonus_v_large	bonus_v_infantry	damage	ap_damage	weapon_length	melee_weapon_type	audio_type	splash_attack_target_size	splash_attack_max_attacks	splash_attack_power_multiplier	building_damage_multiplier	ignition_amount	is_magical	contact_phase	collision_attack_max_targets	collision_attack_max_targets_cooldown	melee_attack_interval	scaling_damage	is_spell
+#melee_weapons_tables;25;db/melee_weapons_tables/zzz_cbfm_beorg_antilarge																			
+wh3_dlc27_nor_cha_beorg_claws	20	0	220	230	2.0000	axe	creatures_claws	medium	5	1.5000	1.2500	0.0000	false		0	10	4.0000		false


### PR DESCRIPTION
gives Beorg bonus v large instead of bonus v infantry, considering he has colossal strike and bvl descriptor