### PR TITLE
Fix for issue #2607 , buggy building in k8p

### DIFF
--- a/db/building_chain_set_items_tables/zzz_cbfm_skarsnik_salt.tsv
+++ b/db/building_chain_set_items_tables/zzz_cbfm_skarsnik_salt.tsv
@@ -1,0 +1,3 @@
+chain	set	super_chain	remove
+#building_chain_set_items_tables;0;db/building_chain_set_items_tables/zzz_cbfm_skarsnik_salt			
+wh_dlc06_GREENSKIN_boars_skarsnik	wh3_main_secondary_addon_landmark_eight_peaks		true


### PR DESCRIPTION
Disables wh_dlc06_GREENSKIN_boars_skarsnik in building_chain_set_items_tables, haven't noticed it causing other issues besides removing the building