### PR TITLE
Fix for issue #2602 , missing Oglok trait info

### DIFF
--- a/db/trait_level_effects_tables/zzz_cbfm_oglok_tooltip_dummy.tsv
+++ b/db/trait_level_effects_tables/zzz_cbfm_oglok_tooltip_dummy.tsv
@@ -1,0 +1,4 @@
+trait_level	effect	effect_scope	value
+#trait_level_effects_tables;0;db/trait_level_effects_tables/zzz_cbfm_oglok_tooltip_dummy			
+wh2_main_trait_innate_dummy_oglok	wh3_main_effect_force_enable_fear_vs_dwarfs	general_to_force_own	0.0000
+wh2_main_trait_innate_dummy_oglok	wh3_main_effect_character_stat_unit_mass_percentage_mod	character_to_character_own	15.0000

--- a/db/twad_key_deletes_tables/zzz_cbfm_oglok_tooltip_dummy.tsv
+++ b/db/twad_key_deletes_tables/zzz_cbfm_oglok_tooltip_dummy.tsv
@@ -1,0 +1,3 @@
+key	table_name
+#twad_key_deletes_tables;0;db/twad_key_deletes_tables/zzz_cbfm_oglok_tooltip_dummy	
+wh2_main_trait_innate_dummy_oglokwh_main_effect_tech_hitpoints_increase_boyz	trait_level_effects

--- a/text/db/!cbfm_oglok_tooltip_dummy.loc.tsv
+++ b/text/db/!cbfm_oglok_tooltip_dummy.loc.tsv
@@ -1,0 +1,3 @@
+key	text	tooltip
+#Loc;1;text/db/!cbfm_oglok_tooltip_dummy.loc		
+effects_description_wh3_main_effect_force_enable_fear_vs_dwarfs	Attribute: Causes Fear when fighting against Dwarfs	false


### PR DESCRIPTION
Removes armor from Ogloks dummytrait via datasnipe and adding in actual traits. Also fixes spelling error for the fear vs dwarfs trait