### PR TITLE
Fix for #2631 , obsidian axe intensity reset

### DIFF
--- a/db/twad_key_deletes_tables/zzz_cbfm_obsidianaxe_intensity.tsv
+++ b/db/twad_key_deletes_tables/zzz_cbfm_obsidianaxe_intensity.tsv
@@ -1,0 +1,3 @@
+key	table_name
+#twad_key_deletes_tables;0;db/twad_key_deletes_tables/zzz_cbfm_obsidianaxe_intensity	
+wh3_dlc23_weapon_passive_the_obsidian_axeout_of_melee	special_ability_to_auto_deactivate_flags


### PR DESCRIPTION
datasnipes the effect that makes resets this ability when out of melee