### PR TITLE
Fix for issuw #2638 , hellforge longbeard thumbnail

### DIFF
--- a/db/unit_set_to_unit_junctions_tables/zzz_cbfm_manufactory_longbeard_icon.tsv
+++ b/db/unit_set_to_unit_junctions_tables/zzz_cbfm_manufactory_longbeard_icon.tsv
@@ -1,0 +1,4 @@
+unit_caste	unit_category	unit_class	unit_record	unit_set	exclude
+#unit_set_to_unit_junctions_tables;1;db/unit_set_to_unit_junctions_tables/zzz_cbfm_manufactory_longbeard_icon					
+			wh3_dlc27_chd_mon_bale_taurus_monst_arcanum	wh3_dlc23_chd_category_flying_beasts	true
+			wh3_dlc27_chd_mon_lammasu_monst_arcanum	wh3_dlc23_chd_category_flying_beasts	true


### PR DESCRIPTION
Excludes monstrous arcanum units from hellforge so they dont show in ui