### PR TITLE
Fix for issue #2648 , Norscan ice trolls missile block

### DIFF
--- a/db/effect_bonus_value_unit_set_unit_attribute_junctions_tables/zzz_cbfm_missblock_ror_icetroll.tsv
+++ b/db/effect_bonus_value_unit_set_unit_attribute_junctions_tables/zzz_cbfm_missblock_ror_icetroll.tsv
@@ -1,0 +1,3 @@
+bonus_value_id	effect	unit_set_attribute
+#effect_bonus_value_unit_set_unit_attribute_junctions_tables;0;db/effect_bonus_value_unit_set_unit_attribute_junctions_tables/zzz_cbfm_missblock_ror_icetroll		
+enable	360_missile_block_regen_skinwolf_ror	cbfm_360_miss_block

--- a/db/effects_tables/zzz_cbfm_missblock_ror_icetroll.tsv
+++ b/db/effects_tables/zzz_cbfm_missblock_ror_icetroll.tsv
@@ -1,0 +1,3 @@
+effect	icon	priority	icon_negative	category	is_positive_value_good
+#effects_tables;0;db/effects_tables/zzz_cbfm_missblock_ror_icetroll					
+360_missile_block_regen_skinwolf_ror	block_character.png	0	block_character.png	battle	true

--- a/db/technology_effects_junction_tables/zzz_cbfm_missblock_ror_icetroll.tsv
+++ b/db/technology_effects_junction_tables/zzz_cbfm_missblock_ror_icetroll.tsv
@@ -1,0 +1,3 @@
+technology	effect	effect_scope	value
+#technology_effects_junction_tables;0;db/technology_effects_junction_tables/zzz_cbfm_missblock_ror_icetroll			
+wh3_dlc27_tech_nor_mil_regenerating	360_missile_block_regen_skinwolf_ror	faction_to_force_own_unseen	1.0000

--- a/db/unit_set_to_unit_junctions_tables/zzz_cbfm_missblock_ror_icetroll.tsv
+++ b/db/unit_set_to_unit_junctions_tables/zzz_cbfm_missblock_ror_icetroll.tsv
@@ -1,0 +1,6 @@
+unit_caste	unit_category	unit_class	unit_record	unit_set	exclude
+#unit_set_to_unit_junctions_tables;1;db/unit_set_to_unit_junctions_tables/zzz_cbfm_missblock_ror_icetroll					
+			wh_dlc08_nor_mon_norscan_ice_trolls_0	wh3_dlc27_nor_regenerating_r7	false
+			wh_dlc08_nor_mon_norscan_ice_trolls_0	wh3_dlc27_nor_regenerating	false
+			wh_pro04_nor_mon_skinwolves_ror_0	wh3_dlc27_nor_regenerating_r7	true
+			wh_pro04_nor_mon_skinwolves_ror_0	cbfm_360_miss_block_regen_skinwolf	false

--- a/db/unit_set_unit_attribute_junctions_tables/zzz_cbfm_missblock_ror_icetroll.tsv
+++ b/db/unit_set_unit_attribute_junctions_tables/zzz_cbfm_missblock_ror_icetroll.tsv
@@ -1,0 +1,3 @@
+key	unit_attribute	unit_set
+#unit_set_unit_attribute_junctions_tables;0;db/unit_set_unit_attribute_junctions_tables/zzz_cbfm_missblock_ror_icetroll		
+cbfm_360_miss_block	can_block_missiles_360	cbfm_360_miss_block_regen_skinwolf

--- a/db/unit_sets_tables/zzz_cbfm_missblock_ror_icetroll.tsv
+++ b/db/unit_sets_tables/zzz_cbfm_missblock_ror_icetroll.tsv
@@ -1,0 +1,3 @@
+key	use_unit_exp_level_range	min_unit_exp_level_inclusive	max_unit_exp_level_inclusive	special_category
+#unit_sets_tables;2;db/unit_sets_tables/zzz_cbfm_missblock_ror_icetroll				
+cbfm_360_miss_block_regen_skinwolf	false	-1	-1	


### PR DESCRIPTION
Adds ice trolls to What starts the war tech, since all other units have all variants added. Also makes new effect and unit set for skinwolf ror so it benefits