### PR TITLE
Fix for issue #2583 , beorg removal colossal strike

### DIFF
--- a/db/character_skill_nodes_tables/zzz_cbfm_beorg_onslaught.tsv
+++ b/db/character_skill_nodes_tables/zzz_cbfm_beorg_onslaught.tsv
@@ -1,0 +1,3 @@
+key	campaign_key	character_skill_key	faction_key	indent	tier	subculture	points_on_creation	required_num_parents	visible_in_ui
+#character_skill_nodes_tables;6;db/character_skill_nodes_tables/zzz_cbfm_beorg_onslaught									
+wh3_dlc27_skill_node_nor_beorg_self_11		wh_main_skill_all_all_self_deadly_onslaught		2	10		0	4	true


### PR DESCRIPTION
since they changed beorgs damage profile to bvi, this changes colossal strike to deadly onslaught.