### PR TITLE
Fix for #1669, Wulfhart building unlocks

### DIFF
--- a/script/campaign/mod/zzz_cbfm_caravan_unit_rewards.lua
+++ b/script/campaign/mod/zzz_cbfm_caravan_unit_rewards.lua
@@ -1,0 +1,68 @@
+function caravans:reward_item_check(faction, region_key, caravan_master)
+	local culture = faction:culture()
+	local faction_name = faction:name()
+	local reward = self.reward_list[culture][region_key]
+	local anc_exists = false -- CBFM: new variable to track if ancillary exists so function does not need to exit prematurely, precluding other rewards
+	local alt_reward = false -- CBFM: new variable to track if there is an alternate (non-ancillary) reward at stake, so the payload should still be applied even if there is no ancillary available
+
+	-- faction specific override
+	if self.reward_list[faction_name] and self.reward_list[faction_name][region_key] then
+		reward = self.reward_list[faction_name][region_key]
+	end
+
+	-- get a different ancillary if the faction already owns it
+	if faction:ancillary_exists(reward[1]) then
+		if cm:random_number(5) == 1 then
+			local campaign_key = cm:model():campaign_name_key()
+			local item_list = self.special_reward_list[campaign_key][culture]
+
+			-- faction specific override.
+			if self.special_reward_list[campaign_key] and self.special_reward_list[campaign_key][faction_name] then
+				item_list = self.special_reward_list[campaign_key][faction_name]
+			end
+
+			if item_list then
+				reward = item_list[cm:random_number(#item_list)]
+
+				if faction:ancillary_exists(reward[1]) then anc_exists = true end
+			else
+				anc_exists = true
+			end
+		else
+			anc_exists = true
+		end
+	end
+	
+	local character = caravan_master:character()
+	local payload_builder = cm:create_payload()
+	local iron_favor = self.payload_iron_favor;
+	
+	if not anc_exists then
+		payload_builder:character_ancillary_gain(character, reward[1], false)
+	end
+	
+	if reward[3] then
+		payload_builder:add_unit(character:military_force(), reward[3], 1 + cm:get_factions_bonus_value(faction, "chd_convoy_additional_unit_reward_scripted"), 0)
+		alt_reward = true
+	end
+	
+	if reward[4] then
+		payload_builder:faction_pooled_resource_transaction(iron_favor.key, iron_favor.factor, iron_favor.amount, false)
+		alt_reward = true
+	end
+
+	if not anc_exists or alt_reward then
+		cm:trigger_custom_incident_with_targets(
+			faction:command_queue_index(),
+			reward[2],
+			true,
+			payload_builder,
+			0,
+			0,
+			character:command_queue_index(),
+			0,
+			0,
+			0
+		)
+	end
+end

--- a/script/campaign/mod/zzz_cbfm_wulfhart_building_locks.lua
+++ b/script/campaign/mod/zzz_cbfm_wulfhart_building_locks.lua
@@ -1,0 +1,41 @@
+function update_acclaim_bar(factor)
+	local faction = cm:get_faction(wulfhart_faction)
+	
+	local previous_acclaim_value = faction:pooled_resource_manager():resource(acclaim_resource_key):value()
+	
+	if factor and acclaim_resource_factors[factor] and not acclaim_lock then
+		cm:faction_add_pooled_resource(wulfhart_faction, acclaim_resource_key, acclaim_resource_factors[factor][1], acclaim_resource_factors[factor][2])
+	end
+	
+	local current_acclaim_value = faction:pooled_resource_manager():resource(acclaim_resource_key):value()
+	
+	-- BEGIN CBFM FIX
+	local function lock_wulfhart_buildings(index)
+		for i = 1, #wulfhart_buildings_to_unlock[index] do -- Abandoning the pointless "wulfhart_buildings_to_lock" array, which was getting mismatched, in favor of the same table used for unlocking, "wulfhart_buildings_to_unlock"
+			cm:add_event_restricted_building_record_for_faction(wulfhart_buildings_to_unlock[index][i], wulfhart_faction, "wulfhart_building_lock")
+		end
+	end
+	-- END CBFM FIX
+	
+	-- trigger an event reminding about progression reward
+	for i = 1, #acclaim_thresholds do
+		if previous_acclaim_value < acclaim_thresholds[i] and current_acclaim_value >= acclaim_thresholds[i] then
+			cm:trigger_incident(wulfhart_faction, "wh2_dlc13_emp_wulfhart_progress_level_increase", true)
+			
+			for j = 1, #wulfhart_buildings_to_unlock[i + 1] do
+				cm:remove_event_restricted_building_record_for_faction(wulfhart_buildings_to_unlock[i + 1][j], wulfhart_faction)
+			end
+		elseif previous_acclaim_value >= acclaim_thresholds[i] and current_acclaim_value < acclaim_thresholds[i] then
+			lock_wulfhart_buildings(i + 1)
+		elseif current_acclaim_value < acclaim_thresholds[1] then -- CBFM note: This last elseif is actually 100% pointless, but it won't break anything, so we'll leave it in for posterity
+			lock_wulfhart_buildings(1)
+		end
+	end
+	
+	update_imperial_reinforcements_strength()
+	
+	-- trigger endgame mechanics
+	if faction:pooled_resource_manager():resource(acclaim_resource_key):value() >= acclaim_thresholds[#acclaim_thresholds] and not acclaim_lock then
+		acclaim_lock = true
+	end
+end


### PR DESCRIPTION
This script was using two mismatched arrays to the job of one table. This should work as expected now.

Fixes #1669 