### PR TITLE
Fix for #2851, Ritual of the Beast item spawn

### DIFF
--- a/script/campaign/mod/zzz_ritual_of_the_beast_item.lua
+++ b/script/campaign/mod/zzz_ritual_of_the_beast_item.lua
@@ -1,0 +1,11 @@
+if rare_items then
+	table.insert(rare_items, {
+		item = "wh3_dlc24_anc_arcane_item_ritual_of_the_beast",
+		weight = 5,
+		culture_requirement = nil,
+		culture_restriction = nil,
+		faction_culture_override = nil,
+		item_restrictions = nil,
+		effect_bundle_restriction = nil
+	})
+end


### PR DESCRIPTION
This adds it to the rare items spawn script, giving it the same default weight as other items like this. It might be pointless for races like Dwarfs who don't have any Beast casters, but I guess they can sell it.

Fixes #2851