### PR TITLE
Fix for issue #3090 Sky lantern harmony

### DIFF
--- a/db/land_units_to_unit_abilites_junctions_tables/zzz_cbfm_sky_lantern_yin_yang.tsv
+++ b/db/land_units_to_unit_abilites_junctions_tables/zzz_cbfm_sky_lantern_yin_yang.tsv
@@ -1,0 +1,3 @@
+ability	land_unit
+#land_units_to_unit_abilites_junctions_tables;0;db/land_units_to_unit_abilites_junctions_tables/zzz_cbfm_sky_lantern_yin_yang	
+wh3_main_unit_passive_battle_harmony_yang	wh3_main_cth_veh_sky_lantern_0

--- a/db/ui_unit_bullet_point_unit_overrides_tables/zzz_cbfm_sky_lantern_yin_yang.tsv
+++ b/db/ui_unit_bullet_point_unit_overrides_tables/zzz_cbfm_sky_lantern_yin_yang.tsv
@@ -1,0 +1,3 @@
+bullet_point	unit_key
+#ui_unit_bullet_point_unit_overrides_tables;0;db/ui_unit_bullet_point_unit_overrides_tables/zzz_cbfm_sky_lantern_yin_yang	
+yang	wh3_main_cth_veh_sky_lantern_0

--- a/db/unit_attributes_to_groups_junctions_tables/zzz_cbfm_sky_lantern_yin_yang.tsv
+++ b/db/unit_attributes_to_groups_junctions_tables/zzz_cbfm_sky_lantern_yin_yang.tsv
@@ -1,0 +1,3 @@
+attribute	attribute_group
+#unit_attributes_to_groups_junctions_tables;2;db/unit_attributes_to_groups_junctions_tables/zzz_cbfm_sky_lantern_yin_yang	
+yang	wh3_main_cth_veh_sky_lantern_0


### PR DESCRIPTION
Adds yang so it has both yin and yang according to patch 8.0: "The unit can now activate both Yin and Yang Harmony similar to the War Drum"